### PR TITLE
Feature/NQ-865: Adds support for Verilator waiver files in FList tool

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,3 @@
+edalize
+fusesoc
 pre-commit

--- a/sourceme
+++ b/sourceme
@@ -1,3 +1,4 @@
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 VENV=.venv
 
 if [[ ! -e $VENV ]]; then
@@ -5,9 +6,13 @@ if [[ ! -e $VENV ]]; then
     source $VENV/bin/activate
     python -m pip install -U pip wheel
     python -m pip install -r dev_requirements.txt
+    touch $VENV/FUSESOC_IGNORE
 else
     source $VENV/bin/activate
 fi
+
+# FuseSoc Setup
+export FUSESOC_CORES=$DIR
 
 # Install the pre-commit hooks
 pre-commit install

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -101,7 +101,7 @@ class Flist(Edatool):
             self.f.append(f"+incdir+{self.absolute_path(include_dir)}")
 
         # verilog and vlt files are passed to verilator the same way
-        for file in [*vlog_files, *vlt_files]:
+        for file in [*vlt_files, *vlog_files]:
             print(file)
             self.f.append(f"{self.absolute_path(file)}")
 

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -78,17 +78,19 @@ class Flist(Edatool):
                 file_type = file_types[matches[0]]
 
                 # if its valid, add to the right source list
-                if file_type == "systemVerilogSource" or file_type == "verilogSource":
-                    if not self._add_include_dir(f, incdirs):
-                        vlog_files.append(f["name"])
-                elif file_type == "vlt":
-                    vlt_files.append(f["name"])
-                else:
-                    logger.error(
-                        f"""We found a file of type {file_type} which flist
-                        currently does not support. Please remove this from your
-                        core's list of file_types""",
-                    )
+                match file_type:
+                    case "systemVerilogSource" | "verilogSource":
+                        if not self._add_include_dir(f, incdirs):
+                            vlog_files.append(f["name"])
+                    case "vlt":
+                        vlt_files.append(f["name"])
+                    case _:
+                        logger.error(
+                            f"""We found a file of type {file_type} which flist
+                            currently does not support. Please remove this from your
+                            core's list of file_types""",
+                        )
+
             else:
                 unused_files.append(f)
                 depfile = False

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -102,7 +102,6 @@ class Flist(Edatool):
 
         # verilog and vlt files are passed to verilator the same way
         for file in [*vlt_files, *vlog_files]:
-            print(file)
             self.f.append(f"{self.absolute_path(file)}")
 
         output_file = self.name + ".f"

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -57,7 +57,6 @@ class Flist(Edatool):
             file_type = f.get("file_type", "")
             depfile = True
 
-            # get
             matches = [
                 idx
                 for idx, prefix in enumerate(file_types)

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -19,7 +19,13 @@ class Flist(Edatool):
 
     description = "F-list generator"
 
-    TOOL_OPTIONS = {}
+    TOOL_OPTIONS = {
+        "file_types": {
+            "type": "str",
+            "desc": "File types which flist will search for",
+            "list": True,
+        },
+    }
 
     def setup(self, edam):
         super().setup(edam)
@@ -34,19 +40,55 @@ class Flist(Edatool):
             param_str = self._param_value_str(param_value=value, str_quote_style='"')
             self.f.append(f"-pvalue+{self.toplevel}.{key}={param_str}")
 
+        # Get a list of the valid file types. If none is specified use sv and v.
+        file_types = self.tool_options.get(
+            "file_types",
+            ["systemVerilogSource", "verilogSource"],
+        )
+
         incdirs = []
         vlog_files = []
+        vlt_files = []
         depfiles = []
         unused_files = []
 
         for f in self.files:
+
             file_type = f.get("file_type", "")
             depfile = True
-            if file_type.startswith("systemVerilogSource") or file_type.startswith(
-                "verilogSource",
-            ):
-                if not self._add_include_dir(f, incdirs):
-                    vlog_files.append(f["name"])
+
+            # get
+            matches = [
+                idx
+                for idx, prefix in enumerate(file_types)
+                if file_type.startswith(prefix)
+            ]
+
+            # file type matches one of the passed in ones
+            if matches:
+
+                if len(matches) > 1:
+                    logger.warning(
+                        f"""File type matched multiple prefixes ({[file_types
+                        [idx] for idx in matches]}), proceeding with the first
+                        match ({file_types[matches[0]]})""",
+                    )
+
+                # get the type of the first match
+                file_type = file_types[matches[0]]
+
+                # if its valid, add to the right source list
+                if file_type == "systemVerilogSource" or file_type == "verilogSource":
+                    if not self._add_include_dir(f, incdirs):
+                        vlog_files.append(f["name"])
+                elif file_type == "vlt":
+                    vlt_files.append(f["name"])
+                else:
+                    logger.error(
+                        f"""We found a file of type {file_type} which flist
+                        currently does not support. Please remove this from your
+                        core's list of file_types""",
+                    )
             else:
                 unused_files.append(f)
                 depfile = False
@@ -57,8 +99,10 @@ class Flist(Edatool):
         for include_dir in incdirs:
             self.f.append(f"+incdir+{self.absolute_path(include_dir)}")
 
-        for vlog_file in vlog_files:
-            self.f.append(f"{self.absolute_path(vlog_file)}")
+        # verilog and vlt files are passed to verilator the same way
+        for file in [*vlog_files, *vlt_files]:
+            print(file)
+            self.f.append(f"{self.absolute_path(file)}")
 
         output_file = self.name + ".f"
         self.edam = edam.copy()
@@ -110,8 +154,8 @@ def flist(
                     tool: flist
 
     Limitations:
-        The Flist tool currently only writes out Verilog or SV files. It would be good
-        to update it to output Verilator waivers, for example.
+        The Flist tool currently only writes out Verilog, SV files and Verilator
+        Waivers.
 
     Arguments:
         name: VLNV of the core to process or just the N if it resolves to a unique name.

--- a/tests/flist/README.md
+++ b/tests/flist/README.md
@@ -1,0 +1,1 @@
+This directory can be used as a means of demonstrating the functionality of the flist tool. From anywhere in the edalize-plugins repo run `fusesoc run --target flist edalizer:test:flist` and inspect the output in `build/edalizer_test_flist_0/flist/edalizer_test_flist_0.f` for the correct result.

--- a/tests/flist/example.sv
+++ b/tests/flist/example.sv
@@ -1,0 +1,15 @@
+module example (
+    input logic clk,
+    input logic rst,
+    input logic d,
+    output logic [1:0] q
+);
+
+always_ff @( posedge clk, posedge rst ) begin
+    if (rst)
+        q <= '0;
+    else
+        q <= d; // this causes a linting error (WIDTHEXPAND)
+end
+
+endmodule

--- a/tests/flist/flist.core
+++ b/tests/flist/flist.core
@@ -1,0 +1,33 @@
+CAPI=2:
+name: edalizer:test:flist
+description: Toplevel of hierarchy including Xilinx technology primitives.
+
+filesets:
+  rtl:
+    depend:
+      - edalizer:test:flist_child
+    file_type: systemVerilogSource
+
+targets:
+  default: &default
+    filesets:
+      - rtl
+    toplevel: example
+
+  flist:
+    <<: *default
+    flow: generic
+    flow_options:
+      tool: flist
+      file_types:
+        - systemVerilogSource
+        - vlt
+
+  lint:
+    <<: *default
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - -Wall

--- a/tests/flist/flist_child.core
+++ b/tests/flist/flist_child.core
@@ -1,0 +1,40 @@
+CAPI=2:
+name: edalizer:test:flist_child
+description: Toplevel of hierarchy including Xilinx technology primitives.
+
+filesets:
+
+  rtl:
+    files:
+      - example.sv
+    file_type: systemVerilogSource
+
+  verilator_waivers:
+    files:
+      - waiver.vlt
+    file_type: vlt
+
+  # Causes an flist error if - py is included in file_types
+  # as python files are unhandled
+  python_things:
+      files:
+      - example.py
+      file_type: py
+
+targets:
+  default: &default
+    filesets:
+      - rtl
+      - tool_verilator ? (verilator_waivers)
+      - target_flist ? (verilator_waivers)
+      - target_flist ? (python_things)
+    toplevel: example
+
+  lint:
+    <<: *default
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - -Wall

--- a/tests/flist/flist_child.core
+++ b/tests/flist/flist_child.core
@@ -14,13 +14,6 @@ filesets:
       - waiver.vlt
     file_type: vlt
 
-  # Causes an flist error if - py is included in file_types
-  # as python files are unhandled
-  python_things:
-      files:
-      - example.py
-      file_type: py
-
 targets:
   default: &default
     filesets:

--- a/tests/flist/flist_child.core
+++ b/tests/flist/flist_child.core
@@ -27,7 +27,6 @@ targets:
       - rtl
       - tool_verilator ? (verilator_waivers)
       - target_flist ? (verilator_waivers)
-      - target_flist ? (python_things)
     toplevel: example
 
   lint:

--- a/tests/flist/waiver.vlt
+++ b/tests/flist/waiver.vlt
@@ -1,0 +1,3 @@
+`verilator_config
+
+lint_off -rule WIDTHEXPAND -file "*/example.sv"


### PR DESCRIPTION
https://nu-quantum.youtrack.cloud/issue/NQ-866/Add-support-for-Verilator-within-Edalize-cocotb-simulation-flow Describes the scope of the change.

With the current implementation, if a parent core file should include all of its children's waiver files upon a call to `flist`, then each of the children should include the ternary `target_flist ? (verilator_waivers)` in their default target's filesets i.e. 

The child must define:

```
targets:
  default: &default
    filesets:
      - rtl
      - tool_verilator ? (verilator_waivers)
      - target_flist ? (verilator_waivers)
    toplevel: example
```

This is demonstrated in the example in `tests/flist`. It seems you cannot or flags together .. e.g. it would be nice to be able to do `(tool_verilator | target_flist) ? (verilator_waivers)` but that does not seem to work.