### PR TITLE
fix: fixed typing issues with Py3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,6 @@ repos:
     rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
-    hooks:
-    -   id: reorder-python-imports
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0
     hooks:
@@ -30,3 +26,8 @@ repos:
     -   id: flake8
         args:
         -   '--max-line-length=88'
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.17.0
+    hooks:
+      - id: pyupgrade
+        args: [--py39-plus]

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
+simplesat == 0.8.2
 edalize
 fusesoc
 pre-commit

--- a/src/edalize/tools/flist.py
+++ b/src/edalize/tools/flist.py
@@ -165,7 +165,7 @@ class Flist(Edatool):
 
 def flist(
     name: str,
-    flags: list | None = [],
+    flags: Optional[list] = [],
     build_root: Optional[Union[str, Path]] = None,
     work_root: Optional[Union[str, Path]] = None,
     output: Optional[Union[str, Path]] = None,


### PR DESCRIPTION
This fix updates some of the type hints which seem to fail in 3.9. Also added is the pyupgrade pre-commit hook which was missing.